### PR TITLE
Allow CORS to be enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ By default, serves the current working directory on port 8000. If `$GOPATH/bin` 
 
 ### Command-line Arguments
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| -port | `8000` | port to listen on |
-| -dir | `"."` | directory to serve |
+| Flag  | Default | Description                                                  |
+| ----- | ------- | ------------------------------------------------------------ |
+| -port | `8000`  | port to listen on                                            |
+| -dir  | `"."`   | directory to serve                                           |
+| -cors | `false` | `true` to enable CORS (via `Access-Control-Allow-Origin: *`) |

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/danarthurgallagher/serve
+
+go 1.14

--- a/main.go
+++ b/main.go
@@ -9,10 +9,12 @@ import (
 
 var Port int
 var Dir string
+var UseCors bool
 
 func init() {
 	flag.IntVar(&Port, "port", 8000, "port to listen on")
 	flag.StringVar(&Dir, "dir", ".", "directory to serve")
+	flag.BoolVar(&UseCors, "cors", false, "Set true to enable 'Access-Control-Allow-Origin: *' on all requests")
 }
 
 // ResponseWriter wraps http.ResponseWriter to capture the HTTP status code
@@ -23,6 +25,11 @@ type ResponseWriter struct {
 
 func (w *ResponseWriter) WriteHeader(statusCode int) {
 	w.StatusCode = statusCode
+
+	if UseCors {
+		w.ResponseWriter.Header().Add("Access-Control-Allow-Origin", "*")
+	}
+
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 


### PR DESCRIPTION
This PR adds a new flag, `-cors`, which if enabled adds `Access-Control-Allow-Origin: *` to all requests. This helps if testing locally with a directory that will be served from a different domain in production.

This branch is opening with a `go.mod` file that I will update to match your destination directory,